### PR TITLE
test: add home page navigation e2e

### DIFF
--- a/tests/e2e/home/home-booking.e2e.spec.ts
+++ b/tests/e2e/home/home-booking.e2e.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Home page', () => {
+  test('navigates to booking page via hero link', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: /réparation et entretien de vélo à domicile/i })).toBeVisible();
+    await page.getByRole('link', { name: /prendre rendez-vous/i }).click();
+    await expect(page).toHaveURL(/\/book$/);
+    await expect(page.getByRole('heading', { name: /nouvelle demande d/i })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add Playwright test to ensure home page links to booking flow

## Testing
- `npx playwright test tests/e2e/home/home-booking.e2e.spec.ts` *(fails: browsers need installation)*
- `npx playwright install chromium firefox webkit` *(fails: 403 Forbidden downloads)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6153746c8331a1a3b4165c136656